### PR TITLE
Fix PushTopic subscribers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     salesforce_streamer (0.1.0)
-      faye (~> 1.2.4)
+      faye (~> 0.8.9)
       restforce (~> 3.1.0)
 
 GEM
@@ -31,21 +31,19 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.13.1)
       faraday (>= 0.7.4, < 1.0)
-    faye (1.2.4)
+    faye (0.8.11)
       cookiejar (>= 0.3.0)
       em-http-request (>= 0.3.0)
       eventmachine (>= 0.12.0)
-      faye-websocket (>= 0.9.1)
-      multi_json (>= 1.0.0)
+      faye-websocket (>= 0.4.0)
       rack (>= 1.0.0)
-      websocket-driver (>= 0.5.1)
+      yajl-ruby (>= 1.0.0)
     faye-websocket (0.10.9)
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
     hashie (3.6.0)
     http_parser.rb (0.6.0)
     json (2.2.0)
-    multi_json (1.13.1)
     multipart-post (2.1.1)
     public_suffix (3.1.1)
     rack (2.0.7)
@@ -77,6 +75,7 @@ GEM
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
+    yajl-ruby (1.4.1)
 
 PLATFORMS
   ruby

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ base: &DEFAULT
       name: "AllAccounts"
       api_version: "41.0"
       description: "Sync Accounts"
-      notify_fields_for: "Referenced"
+      notify_for_fields: "Referenced"
       query: "Select Id, Name From Account"
 
 development:

--- a/lib/salesforce_streamer/salesforce_client.rb
+++ b/lib/salesforce_streamer/salesforce_client.rb
@@ -24,9 +24,8 @@ module SalesforceStreamer
 
     # Returns true or raises an exception if the upsert fails
     def upsert_push_topic(push_topic)
-      @client.upsert!(
-        'PushTopic',
-        push_topic.id,
+      @client.upsert!('PushTopic', :Id,
+        'Id'              => push_topic.id,
         'Name'            => push_topic.name,
         'ApiVersion'      => push_topic.api_version,
         'Description'     => push_topic.description,

--- a/lib/salesforce_streamer/server.rb
+++ b/lib/salesforce_streamer/server.rb
@@ -34,7 +34,7 @@ module SalesforceStreamer
           @client.subscribe topic.name, replay: topic.replay.to_i do |msg|
             @logger.debug(msg)
             topic.handler_constant.call(msg)
-            @logger.info("Message processed: channel=#{msg['channel']} replayId=#{msg.dig('data', 'event', 'replayId')}")
+            @logger.info("Message processed: channel=#{topic.name} replayId=#{msg.dig('event', 'replayId')}")
           end
         end
       end

--- a/lib/salesforce_streamer/server.rb
+++ b/lib/salesforce_streamer/server.rb
@@ -7,7 +7,7 @@ module SalesforceStreamer
     def initialize(config:, push_topics: [])
       @logger = config.logger
       @push_topics = push_topics
-      @client = ::SalesforceStreamer.salesforce_client
+      @client = Restforce.new
     end
 
     def run
@@ -30,8 +30,8 @@ module SalesforceStreamer
 
     def start_em
       EM.run do
-        @push_topics.each do |topic|
-          @client.subscribe(topic.name, replay: topic.replay) do |msg|
+        @push_topics.map do |topic|
+          @client.subscribe topic.name, replay: topic.replay.to_i do |msg|
             @logger.debug(msg)
             topic.handler_constant.call(msg)
             @logger.info("Message processed: channel=#{msg['channel']} replayId=#{msg.dig('data', 'event', 'replayId')}")

--- a/lib/salesforce_streamer/topic_manager.rb
+++ b/lib/salesforce_streamer/topic_manager.rb
@@ -32,9 +32,8 @@ module SalesforceStreamer
       @logger.debug "Remote PushTopic found with hash=#{hashie.to_h}"
       push_topic.id = hashie.Id
       return true unless push_topic.query.eql?(hashie.Query)
-      return true unless push_topic.name.eql?(hashie.Name)
       return true unless push_topic.notify_for_fields.eql?(hashie.NotifyForFields)
-      return true unless push_topic.api_version.eql?(hashie.ApiVersion)
+      return true unless push_topic.api_version.to_s.eql?(hashie.ApiVersion.to_s)
       @logger.debug 'No differences detected'
       false
     end

--- a/salesforce_streamer.gemspec
+++ b/salesforce_streamer.gemspec
@@ -40,5 +40,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "byebug", "~> 11.0.1"
   spec.add_development_dependency "codecov", "~> 0.1.14"
   spec.add_dependency "restforce", "~> 3.1.0"
-  spec.add_dependency "faye", "~> 1.2.4"
+  spec.add_dependency "faye", "~> 0.8.9"
 end

--- a/spec/salesforce_streamer/salesforce_client_spec.rb
+++ b/spec/salesforce_streamer/salesforce_client_spec.rb
@@ -79,13 +79,14 @@ RSpec.describe SalesforceStreamer::SalesforceClient do
       it 'calls Restforce.upsert with proper arguments' do
         push_topic.id = 123
         attribute_hash = {
+          'Id' => 123,
           'Name' => 'Name',
           'ApiVersion' => '41.0',
           'Description' => 'Name',
           'NotifyForFields' => 'Referenced',
           'Query' => 'Select Id From Account'
         }
-        args = ['PushTopic', 123, attribute_hash]
+        args = ['PushTopic', :Id, attribute_hash]
         expect(restforce).to receive(:upsert!).with(*args)
         subject
       end

--- a/spec/salesforce_streamer/topic_manager_spec.rb
+++ b/spec/salesforce_streamer/topic_manager_spec.rb
@@ -76,20 +76,6 @@ RSpec.describe SalesforceStreamer::TopicManager do
           subject
         end
 
-        it 'upsert when push topic name changes' do
-          h = {
-            Id: 'a1',
-            Name: 'OldName',
-            NotifyForFields: push_topics[0].notify_for_fields,
-            Query: push_topics[0].query,
-            ApiVersion: push_topics[0].api_version
-          }
-          response = OpenStruct.new(h)
-          allow(client).to receive(:find_push_topic_by_name) { response }
-          expect(client).to receive(:upsert_push_topic)
-          subject
-        end
-
         it 'upsert when push topic query changes' do
           h = {
             Id: 'a1',


### PR DESCRIPTION
While manually testing the EM loop, the subscribers were not receiving
any pushtopic events.  A simple script that started an EM loop with a
single subscriber to the same Sf instance and topic name worked as
expected.

There was a difference in the output of `lsof` between the
two running programs. The script had 2 TCP file descriptors open and
connected to a port on an SF host while the server only had 1.  After
swapping out the reused SalesforceStreamer for a fresh client, the
pushtopic events began flowing as expected. Not sure the root cause but
likely has something to do with the the Restforce client not being
thread safe. Afterall, the maintainers do mention in the README of
restforce/restforce:

> It is also important to note that the client object should not be
> reused across different threads, otherwise you may encounter
> thread-safety issues.