### PR TITLE
Make the gem more configurable outside of command line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 
 # rspec failure tracking
 .rspec_status
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
-source "https://rubygems.org"
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
 
 # Specify your gem's dependencies in salesforce_streamer.gemspec
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    salesforce_streamer (0.1.0)
+    salesforce_streamer (0.1.1)
       faye (~> 0.8.9)
       restforce (~> 3.1.0)
 
@@ -89,4 +89,4 @@ DEPENDENCIES
   salesforce_streamer!
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Launch the `streamer` service, pointing it to your push topic configuration YAML
 file and the entry point to your application.
 
 ```
-$ bundle exec streamer -C config/streamer.yml -r ./lib/app -x -v INFO
+$ bundle exec streamer -x -v INFO
 I, [2019-07-09T15:19:55.862296 #78537]  INFO -- : Launching Streamer Services
 I, [2019-07-09T15:19:55.862351 #78537]  INFO -- : Running Topic Manager
 I, [2019-07-09T15:19:56.860998 #78537]  INFO -- : New PushTopic AllAccounts
@@ -111,7 +111,7 @@ variable, or default to `:development` if not set. You can override this in the
 CLI with the `-e ENV` flag.
 
 ```
-$ bundle exec streamer -C config/streamer.yml -r ./lib/app -e production
+$ bundle exec streamer -e production
 ```
 
 ## Development

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,8 @@
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
+# frozen_string_literal: true
+
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+task default: :spec

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,8 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
-require "bundler/setup"
-require "salesforce_streamer"
+require 'bundler/setup'
+require 'salesforce_streamer'
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
@@ -10,5 +11,5 @@ require "salesforce_streamer"
 # require "pry"
 # Pry.start
 
-require "irb"
+require 'irb'
 IRB.start(__FILE__)

--- a/exe/streamer
+++ b/exe/streamer
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'salesforce_streamer'
 require 'salesforce_streamer/cli'

--- a/lib/core_extensions/cookiejar/cookie_validation.rb
+++ b/lib/core_extensions/cookiejar/cookie_validation.rb
@@ -10,7 +10,6 @@ module CoreExtensions
     module CookieValidation
       def self.extended(base)
         base.class_eval do
-
           def self.domains_match(tested_domain, base_domain)
             return true if tested_domain[-15..-1].eql?('.salesforce.com')
 
@@ -21,7 +20,6 @@ module CoreExtensions
               domain == tested_domain
             end
           end
-
         end
       end
     end

--- a/lib/salesforce_streamer.rb
+++ b/lib/salesforce_streamer.rb
@@ -43,14 +43,17 @@ require 'core_extensions/cookiejar/cookie_validation'
 #
 # Turn on verbose logging for troubleshooting. The -r flag will activate the
 # Restforce logger, so this is not recommended for production. The -v flag
-# activates a Logger to STDOUT with DEBUG level by default. Set the log level
+# activates a Logger to STDERR with DEBUG level by default. Set the log level
 # with the -v flag.
 #
-#     bundle exec streamer -C config/streamer.yml -r
+#     bundle exec streamer
 #     bundle exec streamer -C config/streamer.yml -v
 #     bundle exec streamer -C config/streamer.yml -v INFO
 #     bundle exec streamer -C config/streamer.yml -r -v
 #     bundle exec streamer -C config/streamer.yml -r -v INFO
 #
 module SalesforceStreamer
+  def self.config
+    Configuration.instance
+  end
 end

--- a/lib/salesforce_streamer/cli.rb
+++ b/lib/salesforce_streamer/cli.rb
@@ -5,7 +5,6 @@ module SalesforceStreamer
     def initialize(argv)
       @argv = argv
       @config = Configuration.new
-      @push_topics_loaded = false
       setup_options
       @parser.parse! @argv
     end
@@ -18,7 +17,7 @@ module SalesforceStreamer
     private
 
     def validate!
-      raise(MissingCLIFlagError, '--config PATH') unless @push_topics_loaded
+      @config.load_push_topic_data!
       raise(MissingCLIFlagError, '--require PATH') unless @config.require_path
     rescue MissingCLIFlagError => e
       puts e
@@ -29,8 +28,7 @@ module SalesforceStreamer
     def setup_options
       @parser = OptionParser.new do |o|
         o.on "-C", "--config PATH", "Load PATH as a config file" do |arg|
-          @config.load_push_topic_data arg
-          @push_topics_loaded = true
+          @config.config_file = arg
         end
 
         o.on "-e", "--environment ENVIRONMENT",
@@ -47,7 +45,7 @@ module SalesforceStreamer
         end
 
         o.on "-v", "--verbose LEVEL", "Set the log level (default no logging)" do |arg|
-          logger = Logger.new(STDOUT)
+          logger = Logger.new(STDERR)
           logger.level = arg
           @config.logger = logger
         end

--- a/lib/salesforce_streamer/cli.rb
+++ b/lib/salesforce_streamer/cli.rb
@@ -17,39 +17,39 @@ module SalesforceStreamer
 
     def setup_options
       @parser = OptionParser.new do |o|
-        o.on "-C", "--config PATH", "Load PATH as a config file" do |arg|
+        o.on '-C', '--config PATH', 'Load PATH as a config file' do |arg|
           @config.config_file = arg
         end
 
-        o.on "-e", "--environment ENVIRONMENT",
-          "The environment to run the app on (default development)" do |arg|
+        o.on '-e', '--environment ENVIRONMENT',
+             'The environment to run the app on (default development)' do |arg|
           @config.environment = arg
         end
 
-        o.on "-r", "--require PATH", "Load PATH as the entry point to your application" do |arg|
+        o.on '-r', '--require PATH', 'Load PATH as the entry point to your application' do |arg|
           @config.require_path = arg
         end
 
-        o.on "--verbose-restforce", "Activate the Restforce logger" do
+        o.on '--verbose-restforce', 'Activate the Restforce logger' do
           @config.restforce_logger!
         end
 
-        o.on "-v", "--verbose LEVEL", "Set the log level (default no logging)" do |arg|
+        o.on '-v', '--verbose LEVEL', 'Set the log level (default no logging)' do |arg|
           @config.logger = Logger.new(STDERR, level: arg)
         end
 
-        o.on "-V", "--version", "Print the version information" do
+        o.on '-V', '--version', 'Print the version information' do
           puts "streamer version #{SalesforceStreamer::VERSION}"
           exit 0
         end
 
-        o.on "-x", "--topics", "Activate PushTopic Management (default off)" do
+        o.on '-x', '--topics', 'Activate PushTopic Management (default off)' do
           @config.manage_topics = true
         end
 
-        o.banner = "bundle exec streamer OPTIONS"
+        o.banner = 'bundle exec streamer OPTIONS'
 
-        o.on_tail "-h", "--help", "Show help" do
+        o.on_tail '-h', '--help', 'Show help' do
           puts o
           exit 0
         end

--- a/lib/salesforce_streamer/cli.rb
+++ b/lib/salesforce_streamer/cli.rb
@@ -4,26 +4,16 @@ module SalesforceStreamer
   class CLI
     def initialize(argv)
       @argv = argv
-      @config = Configuration.new
+      @config = Configuration.instance
       setup_options
       @parser.parse! @argv
     end
 
     def run
-      validate!
-      Launcher.new(config: @config).run
+      Launcher.new.run
     end
 
     private
-
-    def validate!
-      @config.load_push_topic_data!
-      raise(MissingCLIFlagError, '--require PATH') unless @config.require_path
-    rescue MissingCLIFlagError => e
-      puts e
-      puts @parser
-      exit 1
-    end
 
     def setup_options
       @parser = OptionParser.new do |o|
@@ -45,9 +35,7 @@ module SalesforceStreamer
         end
 
         o.on "-v", "--verbose LEVEL", "Set the log level (default no logging)" do |arg|
-          logger = Logger.new(STDERR)
-          logger.level = arg
-          @config.logger = logger
+          @config.logger = Logger.new(STDERR, level: arg)
         end
 
         o.on "-V", "--version", "Print the version information" do
@@ -59,7 +47,7 @@ module SalesforceStreamer
           @config.manage_topics = true
         end
 
-        o.banner = "streamer OPTIONS"
+        o.banner = "bundle exec streamer OPTIONS"
 
         o.on_tail "-h", "--help", "Show help" do
           puts o

--- a/lib/salesforce_streamer/configuration.rb
+++ b/lib/salesforce_streamer/configuration.rb
@@ -3,22 +3,28 @@
 module SalesforceStreamer
   # Manages server configuration.
   class Configuration
-    attr_accessor :environment, :logger, :require_path
-    attr_reader :push_topic_data
+    attr_accessor :environment, :logger, :require_path, :config_file
     attr_writer :manage_topics
+
+    def self.instance
+      @instance ||= new
+    end
 
     def initialize
       @environment = ENV['RACK_ENV'] || :development
       @logger = Logger.new(IO::NULL)
       @manage_topics = false
+      @config_file = './config/streamer.yml'
+      @require_path = './config/application'
     end
 
     def manage_topics?
       @manage_topics
     end
 
-    def load_push_topic_data(path)
-      data = YAML.safe_load(File.read(path), [], [], true)
+    def push_topic_data
+      return @push_topic_data if @push_topic_data
+      data = YAML.safe_load(File.read(config_file), [], [], true)
       @push_topic_data = data[environment.to_s]
     end
 

--- a/lib/salesforce_streamer/configuration.rb
+++ b/lib/salesforce_streamer/configuration.rb
@@ -3,8 +3,7 @@
 module SalesforceStreamer
   # Manages server configuration.
   class Configuration
-    attr_accessor :environment, :logger, :require_path, :config_file
-    attr_writer :manage_topics
+    attr_accessor :environment, :logger, :require_path, :config_file, :manage_topics, :server
 
     def self.instance
       @instance ||= new

--- a/lib/salesforce_streamer/configuration.rb
+++ b/lib/salesforce_streamer/configuration.rb
@@ -23,6 +23,7 @@ module SalesforceStreamer
 
     def push_topic_data
       return @push_topic_data if @push_topic_data
+
       data = YAML.safe_load(File.read(config_file), [], [], true)
       @push_topic_data = data[environment.to_s]
     end

--- a/lib/salesforce_streamer/errors.rb
+++ b/lib/salesforce_streamer/errors.rb
@@ -15,7 +15,7 @@ module SalesforceStreamer
 
   class PushTopicHandlerMissingError < StandardError
     def initialize(message)
-      super "Unable to load constant #{message.to_s}."
+      super "Unable to load constant #{message}."
     end
   end
 

--- a/lib/salesforce_streamer/launcher.rb
+++ b/lib/salesforce_streamer/launcher.rb
@@ -5,12 +5,11 @@ module SalesforceStreamer
   # Streaming API server. It is responsible for upserting each PushTopic and
   # starting the server.
   class Launcher
-    def initialize(config:)
-      @config = config
-      @logger = config.logger
+    def initialize
+      @logger = Configuration.instance.logger
       load_server_configuration
-      @manager = TopicManager.new push_topics: @push_topics, config: @config
-      @server = Server.new push_topics: @push_topics, config: @config
+      @manager = TopicManager.new push_topics: @push_topics
+      @server = Server.new push_topics: @push_topics
     end
 
     # Manages each PushTopic configured and starts the Streaming API listener.
@@ -29,16 +28,16 @@ module SalesforceStreamer
     end
 
     def require_application
-      if @config.require_path
+      if Configuration.instance.require_path
         @logger.debug 'Loading the require path'
-        require @config.require_path
+        require Configuration.instance.require_path
       end
     end
 
     def initialize_push_topics
       @logger.debug 'Loading and validating PushTopics configuration'
       @push_topics = []
-      @config.push_topic_data.values.each do |topic_data|
+      Configuration.instance.push_topic_data.values.each do |topic_data|
         @logger.debug topic_data.to_s
         @push_topics << PushTopic.new(data: topic_data)
       end

--- a/lib/salesforce_streamer/push_topic.rb
+++ b/lib/salesforce_streamer/push_topic.rb
@@ -5,7 +5,7 @@ module SalesforceStreamer
   class PushTopic
     attr_accessor :id
     attr_reader :name, :replay, :description, :notify_for_fields, :query,
-      :handler, :handler_constant, :api_version
+                :handler, :handler_constant, :api_version
 
     def initialize(data:)
       @handler           = data['handler']
@@ -28,6 +28,7 @@ module SalesforceStreamer
 
     def validate!
       raise(PushTopicNameTooLongError, @name) if @name.size > 25
+
       @handler_constant = Object.const_get(@handler)
       true
     rescue NameError, TypeError => e
@@ -37,6 +38,7 @@ module SalesforceStreamer
 
     def strip_spaces(str)
       raise(NilQueryError, @name) unless str
+
       str.gsub(/\s+/, ' ')
     end
   end

--- a/lib/salesforce_streamer/salesforce_client.rb
+++ b/lib/salesforce_streamer/salesforce_client.rb
@@ -25,21 +25,20 @@ module SalesforceStreamer
     # Returns true or raises an exception if the upsert fails
     def upsert_push_topic(push_topic)
       @client.upsert!('PushTopic', :Id,
-        'Id'              => push_topic.id,
-        'Name'            => push_topic.name,
-        'ApiVersion'      => push_topic.api_version,
-        'Description'     => push_topic.description,
-        'NotifyForFields' => push_topic.notify_for_fields,
-        'Query'           => push_topic.query
-      )
+                      'Id' => push_topic.id,
+                      'Name' => push_topic.name,
+                      'ApiVersion' => push_topic.api_version,
+                      'Description' => push_topic.description,
+                      'NotifyForFields' => push_topic.notify_for_fields,
+                      'Query' => push_topic.query)
     end
 
     private
 
     QUERY = <<~SOQL.chomp.freeze
-    SELECT Id, Name, ApiVersion, Description, NotifyForFields, Query, isActive
-    FROM PushTopic
-    WHERE Name = '{{NAME}}'
+      SELECT Id, Name, ApiVersion, Description, NotifyForFields, Query, isActive
+      FROM PushTopic
+      WHERE Name = '{{NAME}}'
     SOQL
   end
 end

--- a/lib/salesforce_streamer/server.rb
+++ b/lib/salesforce_streamer/server.rb
@@ -4,8 +4,13 @@ module SalesforceStreamer
   class Server
     attr_writer :push_topics
 
-    def initialize(config:, push_topics: [])
-      @logger = config.logger
+    def self.configure
+      yield Configuration.instance
+      Configuration.instance.server = self
+    end
+
+    def initialize(push_topics: [])
+      @logger = Configuration.instance.logger
       @push_topics = push_topics
       @client = Restforce.new
     end

--- a/lib/salesforce_streamer/server.rb
+++ b/lib/salesforce_streamer/server.rb
@@ -4,11 +4,6 @@ module SalesforceStreamer
   class Server
     attr_writer :push_topics
 
-    def self.configure
-      yield Configuration.instance
-      Configuration.instance.server = self
-    end
-
     def initialize(push_topics: [])
       @logger = Configuration.instance.logger
       @push_topics = push_topics

--- a/lib/salesforce_streamer/topic_manager.rb
+++ b/lib/salesforce_streamer/topic_manager.rb
@@ -4,10 +4,9 @@ module SalesforceStreamer
   class TopicManager
     attr_reader :push_topics
 
-    def initialize(push_topics:, config:)
+    def initialize(push_topics:)
       @push_topics = push_topics
-      @config = config
-      @logger = config.logger
+      @logger = Configuration.instance.logger
       @client = SalesforceClient.new
     end
 
@@ -40,7 +39,7 @@ module SalesforceStreamer
 
     def upsert(push_topic)
       @logger.info "Upsert PushTopic #{push_topic.name}"
-      if @config.manage_topics?
+      if Configuration.instance.manage_topics?
         @client.upsert_push_topic(push_topic)
       else
         @logger.info 'Skipping upsert because manage topics is off'

--- a/lib/salesforce_streamer/topic_manager.rb
+++ b/lib/salesforce_streamer/topic_manager.rb
@@ -14,9 +14,7 @@ module SalesforceStreamer
       @logger.info 'Running Topic Manager'
       @push_topics.each do |push_topic|
         @logger.debug push_topic.to_s
-        if diff?(push_topic)
-          upsert(push_topic)
-        end
+        upsert(push_topic) if diff?(push_topic)
       end
     end
 
@@ -33,6 +31,7 @@ module SalesforceStreamer
       return true unless push_topic.query.eql?(hashie.Query)
       return true unless push_topic.notify_for_fields.eql?(hashie.NotifyForFields)
       return true unless push_topic.api_version.to_s.eql?(hashie.ApiVersion.to_s)
+
       @logger.debug 'No differences detected'
       false
     end

--- a/salesforce_streamer.gemspec
+++ b/salesforce_streamer.gemspec
@@ -1,44 +1,45 @@
+# frozen_string_literal: true
 
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "salesforce_streamer/version"
+require 'salesforce_streamer/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "salesforce_streamer"
+  spec.name          = 'salesforce_streamer'
   spec.version       = SalesforceStreamer::VERSION
-  spec.authors       = ["Scott Serok"]
-  spec.email         = ["scott@renofi.com"]
+  spec.authors       = ['Scott Serok']
+  spec.email         = ['scott@renofi.com']
 
   spec.summary       = 'A wrapper around the Restforce Streaming API.'
   spec.description   = 'A wrapper around the Restforce Streaming API.'
   spec.homepage      = 'https://github.com/renofi/salesforce_streamer'
-  spec.license       = "MIT"
+  spec.license       = 'MIT'
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
   if spec.respond_to?(:metadata)
-    spec.metadata["homepage_uri"] = spec.homepage
-    spec.metadata["source_code_uri"] = spec.homepage
-    spec.metadata["changelog_uri"] = spec.homepage
+    spec.metadata['homepage_uri'] = spec.homepage
+    spec.metadata['source_code_uri'] = spec.homepage
+    spec.metadata['changelog_uri'] = spec.homepage
   else
-    raise "RubyGems 2.0 or newer is required to protect against " \
-      "public gem pushes."
+    raise 'RubyGems 2.0 or newer is required to protect against ' \
+      'public gem pushes.'
   end
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
+  spec.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
-  spec.bindir        = "exe"
+  spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "byebug", "~> 11.0.1"
-  spec.add_development_dependency "codecov", "~> 0.1.14"
-  spec.add_dependency "restforce", "~> 3.1.0"
-  spec.add_dependency "faye", "~> 0.8.9"
+  spec.add_development_dependency 'bundler', '~> 2.0'
+  spec.add_development_dependency 'byebug', '~> 11.0.1'
+  spec.add_development_dependency 'codecov', '~> 0.1.14'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_dependency 'faye', '~> 0.8.9'
+  spec.add_dependency 'restforce', '~> 3.1.0'
 end

--- a/spec/salesforce_streamer/configuration_spec.rb
+++ b/spec/salesforce_streamer/configuration_spec.rb
@@ -6,18 +6,20 @@ RSpec.describe SalesforceStreamer::Configuration do
 
     specify { expect(subject).to respond_to(:environment) }
     specify { expect(subject).to respond_to(:environment=) }
+    specify { expect(subject).to respond_to(:config_file) }
+    specify { expect(subject).to respond_to(:config_file=) }
     specify { expect(subject).to respond_to(:logger) }
     specify { expect(subject).to respond_to(:logger=) }
-    specify { expect(subject).to respond_to(:push_topic_data) }
     specify { expect(subject).not_to respond_to(:push_topic_data=) }
   end
 
-  describe '#load_push_topic_data' do
+  describe '#push_topic_data' do
     let(:config) { described_class.new }
-    subject { config.load_push_topic_data path }
+
+    subject { config.push_topic_data }
 
     context 'when YAML file has development key' do
-      let(:path) { './spec/fixtures/configuration/config.yml' }
+      before { config.config_file = './spec/fixtures/configuration/config.yml' }
 
       specify { expect(subject).to be_a Hash }
     end

--- a/spec/salesforce_streamer/configuration_spec.rb
+++ b/spec/salesforce_streamer/configuration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # frozen_string_litera: true
 
 RSpec.describe SalesforceStreamer::Configuration do

--- a/spec/salesforce_streamer/launcher_spec.rb
+++ b/spec/salesforce_streamer/launcher_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe SalesforceStreamer::Launcher do
 
     before do
       config.environment = :test
-      config.load_push_topic_data path
+      config.config_file = path
+      config.require_path = nil
     end
 
     describe '.new' do

--- a/spec/salesforce_streamer/launcher_spec.rb
+++ b/spec/salesforce_streamer/launcher_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe SalesforceStreamer::Launcher do
 
   context 'loading push topics from :test' do
     let(:path) { './spec/fixtures/configuration/config.yml' }
-    let(:config) { SalesforceStreamer::Configuration.new }
+    let(:config) { SalesforceStreamer::Configuration.instance }
 
     before do
       config.environment = :test
@@ -20,20 +20,20 @@ RSpec.describe SalesforceStreamer::Launcher do
     end
 
     describe '.new' do
-      subject { described_class.new config: config }
+      subject { described_class.new }
 
       specify { expect(subject).to respond_to :run }
 
       it 'calls TopicManager.new with push_topics loaded from config YAML' do
         expect(SalesforceStreamer::TopicManager)
           .to receive(:new)
-          .with(push_topics: kind_of(Array), config: config)
+          .with(push_topics: kind_of(Array))
         subject
       end
     end
 
     describe '#run' do
-      let(:launcher) { described_class.new config: config }
+      let(:launcher) { described_class.new }
 
       subject { launcher.run }
 

--- a/spec/salesforce_streamer/salesforce_client_spec.rb
+++ b/spec/salesforce_streamer/salesforce_client_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe SalesforceStreamer::SalesforceClient do
     context 'given handler name and replay option' do
       let(:handler_name) { 'TestHandlerClass' }
       let(:options) { { replay: -1 } }
-      let(:block) { Proc.new { 'yield content' } }
+      let(:block) { proc { 'yield content' } }
 
       specify { expect(subject).to eq 'yield content' }
     end

--- a/spec/salesforce_streamer/server_spec.rb
+++ b/spec/salesforce_streamer/server_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe SalesforceStreamer::Server do
             'event' => {
               'createdDate' => '2019-07-10T16:10:16.764Z',
               'replayId' => 50,
-              'type'=>'updated'
+              'type' => 'updated'
             },
             'sobject' => {
               'AccountId' => '0011m00000PU8LrAAL',

--- a/spec/salesforce_streamer/server_spec.rb
+++ b/spec/salesforce_streamer/server_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe SalesforceStreamer::Server do
   before { allow(Restforce).to receive(:new) { client } }
 
   describe '.new' do
-    subject { described_class.new push_topics: push_topics, config: config }
+    subject { described_class.new push_topics: push_topics }
 
     context 'given push_topics: []' do
       let(:push_topics) { [] }
@@ -20,7 +20,7 @@ RSpec.describe SalesforceStreamer::Server do
 
   describe '#run' do
     let(:config) { SalesforceStreamer::Configuration.new }
-    let(:server) { described_class.new config: config, push_topics: push_topics }
+    let(:server) { described_class.new push_topics: push_topics }
 
     subject { server.run }
 

--- a/spec/salesforce_streamer/topic_manager_spec.rb
+++ b/spec/salesforce_streamer/topic_manager_spec.rb
@@ -2,12 +2,13 @@
 
 RSpec.describe SalesforceStreamer::TopicManager do
   let(:client) { double(find_push_topic_by_name: {}, upsert_push_topic: true) }
-  let(:config) { SalesforceStreamer::Configuration.new }
+  let(:config) { SalesforceStreamer::Configuration.instance }
 
+  before { SalesforceStreamer::Configuration.instance.require_path = nil }
   before { allow(SalesforceStreamer::SalesforceClient).to receive(:new) { client } }
 
   describe '.new' do
-    subject { described_class.new push_topics: push_topics, config: config }
+    subject { described_class.new push_topics: push_topics }
 
     context 'when push_topics is []' do
       let(:push_topics) { [] }
@@ -17,7 +18,7 @@ RSpec.describe SalesforceStreamer::TopicManager do
   end
 
   describe '#run' do
-    let(:manager) { described_class.new push_topics: push_topics, config: config }
+    let(:manager) { described_class.new push_topics: push_topics }
 
     subject { manager.run }
 

--- a/spec/salesforce_streamer_spec.rb
+++ b/spec/salesforce_streamer_spec.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 RSpec.describe SalesforceStreamer do
-  it "has a version number" do
+  it 'has a version number' do
     expect(SalesforceStreamer::VERSION).not_to be nil
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/setup'
 require 'byebug'
 


### PR DESCRIPTION
Making the application more runtime configurable by implementing the singleton pattern on the `SalesforceStreamer::Configuration` class and using it around the library.

```ruby
# ./config/initializers/salesforce_streamer.rb

SalesforceStreamer.config.logger = Rails.logger
SalesforceStreamer.config.environment = Rails.env
SalesforceStreamer.config.config_file = "./not/config/streamer.yml"
```