### PR TITLE
add config.exception_adapter option

### DIFF
--- a/lib/salesforce_streamer/configuration.rb
+++ b/lib/salesforce_streamer/configuration.rb
@@ -3,7 +3,7 @@
 module SalesforceStreamer
   # Manages server configuration.
   class Configuration
-    attr_accessor :environment, :logger, :require_path, :config_file, :manage_topics, :server
+    attr_accessor :environment, :logger, :require_path, :config_file, :manage_topics, :server, :exception_adapter
 
     def self.instance
       @instance ||= new
@@ -12,6 +12,7 @@ module SalesforceStreamer
     def initialize
       @environment = ENV['RACK_ENV'] || :development
       @logger = Logger.new(IO::NULL)
+      @exception_adapter = proc { |exc| raise exc }
       @manage_topics = false
       @config_file = './config/streamer.yml'
       @require_path = './config/application'

--- a/lib/salesforce_streamer/server.rb
+++ b/lib/salesforce_streamer/server.rb
@@ -32,9 +32,13 @@ module SalesforceStreamer
       EM.run do
         @push_topics.map do |topic|
           @client.subscribe topic.name, replay: topic.replay.to_i do |msg|
-            @logger.debug(msg)
-            topic.handler_constant.call(msg)
-            @logger.info("Message processed: channel=#{topic.name} replayId=#{msg.dig('event', 'replayId')}")
+            begin
+              @logger.debug(msg)
+              topic.handler_constant.call(msg)
+              @logger.info("Message processed: channel=#{topic.name} replayId=#{msg.dig('event', 'replayId')}")
+            rescue StandardError => e
+              Configuration.instance.exception_adapter.call e
+            end
           end
         end
       end

--- a/spec/salesforce_streamer/configuration_spec.rb
+++ b/spec/salesforce_streamer/configuration_spec.rb
@@ -26,4 +26,16 @@ RSpec.describe SalesforceStreamer::Configuration do
       specify { expect(subject).to be_a Hash }
     end
   end
+
+  describe '#exception_adapter.call(exception)' do
+    let(:config) { described_class.new }
+
+    context 'given an Exception' do
+      let(:exception) { StandardError.new('error') }
+
+      subject { config.exception_adapter.call exception }
+
+      specify { expect { subject }.to raise_exception { exception } }
+    end
+  end
 end

--- a/spec/salesforce_streamer/server_spec.rb
+++ b/spec/salesforce_streamer/server_spec.rb
@@ -71,6 +71,14 @@ RSpec.describe SalesforceStreamer::Server do
           subject
         end
       end
+
+      context 'when subscriber receives a message that raises an exception' do
+        it 'SalesforceStreamer::Configuration.instance.exception_adapter receives .call' do
+          allow(client).to receive(:subscribe).and_yield([])
+          expect(SalesforceStreamer::Configuration.instance.exception_adapter).to receive(:call).with(instance_of(TypeError))
+          subject
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Adds new config option to better handle exceptions raised in any one of the subscription threads.

```ruby
# config/initializers/salesforce_streamer.rb

# define a object that responds to the message `.call(exception)`
SalesforceStreamer.config.exception_adapter = MyApp::ExceptionManager.new
# or a proc
SalesforceStreamer.config.exception_adapter = proc { |exception| Exceptor.capture_exception(exception) }
```