### PR TITLE
Use SETEX Redis command

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    salesforce_streamer (0.2.3)
+    salesforce_streamer (0.3.0)
       faye (= 0.8.9)
       restforce (~> 3.1.0)
 

--- a/lib/salesforce_streamer/replay_persistence.rb
+++ b/lib/salesforce_streamer/replay_persistence.rb
@@ -12,7 +12,7 @@ module SalesforceStreamer
 
       def retrieve(key)
         Configuration.instance.persistence_adapter&.retrieve(key).tap do |v|
-        Log.debug { "Retrieved for #{key} #{ v || 'nil' }" }
+          Log.debug { "Retrieved for #{key} #{v || 'nil'}" }
         end
       end
     end

--- a/lib/salesforce_streamer/version.rb
+++ b/lib/salesforce_streamer/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SalesforceStreamer
-  VERSION = '0.2.3'
+  VERSION = '0.3.0'
 end

--- a/spec/salesforce_streamer/replay_persistence_spec.rb
+++ b/spec/salesforce_streamer/replay_persistence_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe SalesforceStreamer::ReplayPersistence do
       let(:key) { 'key' }
       let(:value) { '123' }
 
-      specify { expect(subject).to eq 1 }
+      specify { expect(subject).to eq 'OK' }
     end
   end
 
@@ -33,7 +33,7 @@ RSpec.describe SalesforceStreamer::ReplayPersistence do
 
       before { [3, 16, 8].each { |value| described_class.record key, value } }
 
-      specify { expect(subject).to eq 16 }
+      specify { expect(subject).to eq 8 }
     end
   end
 end


### PR DESCRIPTION
The previous implementation of the RedisReplay class used the sorted set
operations to gaurantee that the highest messageId would be sent to
Salesforce Streaming API upon booting up.

If that messageId is older than 24 hours, then no messages will be received
from the Salesforce Streaming API.  This is problematic when a
Salesforce PushTopic doesn't receive events very frequently and can lead
to the server doing nothing without warning/errors to the operator.

It's more important that we ensure new events are received by the push
topic than it is to ensure we don't replay a message we already
received.  This is a big assumption that might not be true for all
applications, but for all applications not receiving new events is bad.

The new implementation uses the SETEX command to set the messageId for
the PushTopic with an expiration of 24 hours. This way when the server
reboots after no events for > 24 hours, then the GET command will
retrieve nothing and a -1 will be used to start fetching new events.

The side effect is that if messages are received out of order before the
server restarts, then one or more messages already received may be
replayed.