### PR TITLE
Don't perform connections outside em run block

### DIFF
--- a/lib/salesforce_streamer/server.rb
+++ b/lib/salesforce_streamer/server.rb
@@ -4,11 +4,9 @@ module SalesforceStreamer
 
     def initialize(push_topics: [])
       @push_topics = push_topics
-      @client = Restforce.new
     end
 
     def run
-      @client.authenticate!
       Log.info 'Starting Server'
       catch_signals
       start_em
@@ -25,10 +23,14 @@ module SalesforceStreamer
       end
     end
 
+    def client
+      Restforce.new.tap(&:authenticate!)
+    end
+
     def start_em
       EM.run do
         @push_topics.map do |topic|
-          @client.subscribe topic.name, replay: topic.replay.to_i do |msg|
+          client.subscribe topic.name, replay: topic.replay.to_i do |msg|
             Log.info "Message received from topic #{topic.name}"
             MessageReceiver.call topic.name, topic.handler_constant, msg
           end


### PR DESCRIPTION
I'm not really sure it'll help with anything and it's a kinda blind fix, but I have a feeling that we shouldn't perform any connections outside EM.run block, since it may cause connection issues.