### PR TITLE
Configure Faye.logger

### DIFF
--- a/lib/salesforce_streamer/configuration.rb
+++ b/lib/salesforce_streamer/configuration.rb
@@ -1,7 +1,8 @@
 module SalesforceStreamer
   # Manages server configuration.
   class Configuration
-    attr_accessor :environment, :logger, :require_path, :config_file, :manage_topics, :server, :exception_adapter, :persistence_adapter, :redis_connection
+    attr_accessor :environment, :require_path, :config_file, :manage_topics, :server, :exception_adapter, :persistence_adapter, :redis_connection
+    attr_reader :logger
 
     class << self
       attr_writer :instance
@@ -13,12 +14,12 @@ module SalesforceStreamer
 
     def initialize
       @environment = ENV['RACK_ENV'] || :development
-      @logger = Logger.new(IO::NULL)
       @exception_adapter = proc { |exc| fail(exc) }
       @persistence_adapter = RedisReplay.new
       @manage_topics = false
       @config_file = './config/streamer.yml'
       @require_path = './config/application'
+      self.logger = Logger.new(IO::NULL)
     end
 
     def manage_topics?
@@ -34,6 +35,10 @@ module SalesforceStreamer
 
     def restforce_logger!
       Restforce.log = true
+    end
+
+    def logger=(object)
+      @logger = Faye.logger = object
     end
   end
 end


### PR DESCRIPTION
Faye logs a lot of information which might be helpful in understating what's causing the connection issues https://github.com/faye/faye/blob/0.8.9/lib/faye/protocol/client.rb#L206

Currently we don't see them, since the default logger is `puts`

```
2.6.5 :001 > Faye.logger
 => #<Method: Faye.puts> 
```