### PR TITLE
Do not memoize the response from ReplayPersistence.retrieve

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    salesforce_streamer (0.4.0)
+    salesforce_streamer (0.4.1)
       faye (= 0.8.9)
       restforce (~> 4.2)
 

--- a/lib/salesforce_streamer/push_topic.rb
+++ b/lib/salesforce_streamer/push_topic.rb
@@ -17,9 +17,7 @@ module SalesforceStreamer
     end
 
     def replay
-      @replay ||= (ReplayPersistence.retrieve(name) || @static_replay).tap do |replay_id|
-        Log.info "PushTopic name=#{name} starting at replayId=#{replay_id}"
-      end
+      ReplayPersistence.retrieve(name) || @static_replay
     end
 
     def to_s

--- a/lib/salesforce_streamer/version.rb
+++ b/lib/salesforce_streamer/version.rb
@@ -1,3 +1,3 @@
 module SalesforceStreamer
-  VERSION = '0.4.0'.freeze
+  VERSION = '0.4.1'.freeze
 end

--- a/spec/salesforce_streamer/push_topic_spec.rb
+++ b/spec/salesforce_streamer/push_topic_spec.rb
@@ -4,6 +4,28 @@ RSpec.describe SalesforceStreamer::PushTopic do
 
     subject { push_topic.replay }
 
+    context 'when ReplayPersistence records a change' do
+      let(:data) do
+        {
+          'name' => 'name',
+          'handler' => 'TestHandlerClass',
+          'salesforce' => { 'query' => '', 'name' => 'sfname' }
+        }
+      end
+
+      before do
+        obj = Object.new
+        obj.define_singleton_method(:retrieve) do |_key|
+          SecureRandom.uuid # simulate a difference in value returned from persistence
+        end
+        SalesforceStreamer.config.persistence_adapter = obj
+      end
+
+      it 'the returned value is not memoize' do
+        expect(push_topic.replay).to_not eq push_topic.replay
+      end
+    end
+
     context 'when config.persistence_adapter is nil' do
       let(:data) do
         {


### PR DESCRIPTION
The streamer process records the replayId received from each event. The
algorithm to resubscribe to a PushTopic uses the value returned by
PushTopic#replay. This value was being memoized, and because the
PushTopic object is only initialized once when the streamer process is
started up the PushTopic#replay value becomes stale.

This change incurs some overhead because each subscribe event will not
read from the ReplayPersistence (default Redis) but it will now return
the most recently received replayId.

Without this change, the stale replayId could be as stale as 24 hours or
more. If a subscription to a PushTopic uses a replayId that is older
than the message durability retention period specified by the Salesforce
Streaming API docs then no messages (past, present, or future!) are sent
to the subscribing client.  The current restforce client will receive a
400 error message from the Salesforce API, but do nothing and the
connection and streamer process will appear alive and well but unable to
receive new events!

Fixes #19 