### PR TITLE
Adds ReplayIdErrorExtension to raise exception

### DIFF
--- a/lib/salesforce_streamer.rb
+++ b/lib/salesforce_streamer.rb
@@ -7,6 +7,7 @@ require 'forwardable'
 
 require 'salesforce_streamer/configuration'
 require 'salesforce_streamer/errors'
+require 'salesforce_streamer/replay_id_error_extension'
 require 'salesforce_streamer/log'
 require 'salesforce_streamer/push_topic'
 require 'salesforce_streamer/topic_manager'

--- a/lib/salesforce_streamer/errors.rb
+++ b/lib/salesforce_streamer/errors.rb
@@ -1,4 +1,6 @@
 module SalesforceStreamer
+  ReplayIdError = Class.new(StandardError)
+
   class MissingCLIFlagError < StandardError
     def initialize(flag)
       super 'Missing required command line flag: ' + flag.to_s

--- a/lib/salesforce_streamer/replay_id_error_extension.rb
+++ b/lib/salesforce_streamer/replay_id_error_extension.rb
@@ -1,0 +1,13 @@
+module SalesforceStreamer
+  class ReplayIdErrorExtension
+    REPLAY_ERROR_REGEX = /^400::The replayId /.freeze
+
+    def incoming(message, callback)
+      if message['error']&.match?(REPLAY_ERROR_REGEX)
+        fail ReplayIdError, message['error']
+      end
+
+      callback.call message
+    end
+  end
+end

--- a/lib/salesforce_streamer/server.rb
+++ b/lib/salesforce_streamer/server.rb
@@ -24,7 +24,11 @@ module SalesforceStreamer
     end
 
     def client
-      Restforce.new.tap(&:authenticate!)
+      return @client if @client
+      @client = Restforce.new
+      @client.authenticate!
+      @client.faye.add_extension ReplayIdErrorExtension.new
+      @client
     end
 
     def start_em

--- a/spec/salesforce_streamer/server_spec.rb
+++ b/spec/salesforce_streamer/server_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe SalesforceStreamer::Server do
-  let(:client) { double(authenticate!: true, subscribe: true) }
+  let(:client) { double(authenticate!: true, subscribe: true, faye: double(add_extension: nil)) }
   before { allow(Restforce).to receive(:new) { client } }
 
   describe '.new' do


### PR DESCRIPTION
The Restforce client uses the Faye library to communicate via CometD
with the Salesforce Streaming API. The Restforce Faye client does not
handle application errors from the Streaming API. Particularly if a bad
replayId is given.

This commit adds an extension to the Restforce Faye client to look for
these application specific errors. If a "400" replayId error is found in
the message, then an exception is raised so that the process exits
non-zero.

Examples showing the slight difference in error message based on circumstances:
- I added a String to the Redis database so that the RedisReplay adapter would read a very old replayId for the PushTopic.
```
$ bundle exec streamer
/Users/scott/renofi/salesforce_streamer/lib/salesforce_streamer/replay_id_error_extension.rb:7:in `incoming': 400::The replayId {12} you provided was invalid.  Please provide a valid ID, -2 to replay all events, or -1 to replay only new events. (SalesforceStreamer::ReplayIdError)
```

- I provided a null value for the replay argument when subscribing to a PushTopic directly using the Restforce#subscribe method.
```
$ bundle exec streamer
/Users/scott/renofi/salesforce_streamer/lib/salesforce_streamer/replay_id_error_extension.rb:7:in `incoming': 400::The replayId for channel {/topic/ContactUpdated} wasn't found using the provided replay ID map {{/topic/ContactUpdated=null}}. Ensure that the channel name you provided in the replay map is valid and matches the channel name used for subscribing.  (SalesforceStreamer::ReplayIdError)
```