### PR TITLE
adds "topic" key to message payload

### DIFF
--- a/lib/salesforce_streamer/push_topic.rb
+++ b/lib/salesforce_streamer/push_topic.rb
@@ -21,6 +21,7 @@ module SalesforceStreamer
     end
 
     def handle(message)
+      message['topic'] = @name
       handle_chain.call(message)
       ReplayPersistence.record @name, message.dig('event', 'replayId')
     rescue StandardError => e


### PR DESCRIPTION
Original event payload has the keys `event` and `sobject`. This PR adds `topic` key with the name of the push topic as defined in the configuration of the PushTopic YAML so that any middleware or handler can have access to the name of the push topic.
```yaml
lead_push_topic:
  handler: "LeadChangedHandler"
  replay: -1
  salesforce:
    name: "LeadChangedPushTopic"
    ...
```
```json
{"topic":"LeadChangedPushTopic","event":{...},"sobject":{...}}
```