### PR TITLE
changes expected interface of replay adapter, v2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,38 @@
 Sorted so that the most recent change logs are near the top. Only significant
 changes are logged in the change log.
 
+## 2020-08-17 Scott Serok [scott@renofi.com](mailto:scott@renofi.com)
+
+v2.1 changes the expected interface of `Configuration#replay_adapter`.
+
+Normally this breaking change would require a major version bump, but since the
+functionality today is quiet broken we can call this a major bug fix.
+
+The `config.replay_adapter` should be an object that has an interface like Hash.
+It must respond to `[]` and `[]=`. By default the adapter is an empty hash.  If
+you want your push topic replayId to persist between restarts, then you should
+implement a class with an appropriate interface.
+
+```ruby
+class MyReplayAdapter
+  def [](channel)
+    MyPersistence.get(channel)
+  end
+
+  def []=(channel, replay_id)
+    MyPersistence.set(channel, replay_id)
+  end
+end
+```
+
+This change was sparked by a misunderstanding of the
+`Restforce::Concerns::Streaming::ReplayExtension` replay handlers.
+SalesforceStreamer can eliminate some complexity and fix a bug by delegating the
+responsibility of maintaining the current replayId to that ReplayExtension. The
+object will be used on each request/response cycle to record and read the latest
+replayId as long as the object assigned to `config.replay_adapter` responds to
+`[]` and `[]=`.
+
 ## 2020-08-04 Scott Serok [scott@renofi.com](mailto:scott@renofi.com)
 
 v2.0 is released as a major simplification of this library. There are 2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    salesforce_streamer (2.0.0)
+    salesforce_streamer (2.1.0)
       dry-initializer (~> 3.0)
       faye (~> 1.4)
       restforce (>= 4.2, < 6.0)

--- a/lib/salesforce_streamer/cli.rb
+++ b/lib/salesforce_streamer/cli.rb
@@ -32,7 +32,7 @@ module SalesforceStreamer
         end
 
         o.on '-v', '--verbose LEVEL', 'Set the log level (default no logging)' do |arg|
-          @config.logger = Logger.new(STDERR, level: arg)
+          @config.logger = Logger.new($stderr, level: arg)
         end
 
         o.on '-V', '--version', 'Print the version information' do

--- a/lib/salesforce_streamer/configuration.rb
+++ b/lib/salesforce_streamer/configuration.rb
@@ -21,7 +21,7 @@ module SalesforceStreamer
       @environment = ENV['RACK_ENV'] || :development
       @logger = Logger.new(IO::NULL)
       @exception_adapter = proc { |exc| fail(exc) }
-      @replay_adapter = proc { |topic| topic.id || topic.replay }
+      @replay_adapter = Hash.new { |hash, key| hash[key] = -1 }
       @manage_topics = false
       @config_file = './config/streamer.yml'
       @require_path = './config/environment'

--- a/lib/salesforce_streamer/push_topic.rb
+++ b/lib/salesforce_streamer/push_topic.rb
@@ -34,7 +34,7 @@ module SalesforceStreamer
       @handler = Object.const_get(@handler)
       true
     rescue NameError, TypeError => e
-      message = 'handler=' + @handler.to_s + ' exception=' + e.to_s
+      message = "handler=#{@handler} exception=#{e}"
       raise(PushTopicHandlerMissingError, message)
     end
 

--- a/lib/salesforce_streamer/salesforce_client.rb
+++ b/lib/salesforce_streamer/salesforce_client.rb
@@ -8,10 +8,8 @@ module SalesforceStreamer
       @client.authenticate!
     end
 
-    def subscribe(*args)
-      @client.subscribe(args) do
-        yield
-      end
+    def subscribe(*args, &block)
+      @client.subscribe(args, &block)
     end
 
     # Returns nil or an instance of Restforce::SObject

--- a/lib/salesforce_streamer/server.rb
+++ b/lib/salesforce_streamer/server.rb
@@ -34,12 +34,9 @@ module SalesforceStreamer
     def start_em
       EM.run do
         @push_topics.map do |topic|
-          replay_id = Configuration.instance.replay_adapter.call(topic)
-          client.subscribe topic.name, replay: replay_id.to_i do |message|
-            replay_id = message.dig('event', 'replayId')
-            Log.info "Message #{replay_id} received from topic #{topic.name}"
+          client.subscribe topic.name, replay: Configuration.instance.replay_adapter do |message|
+            Log.info "Message #{message.dig('event', 'replayId')} received from topic #{topic.name}"
             topic.handle message
-            topic.id = replay_id
           end
         end
       end

--- a/lib/salesforce_streamer/version.rb
+++ b/lib/salesforce_streamer/version.rb
@@ -1,3 +1,3 @@
 module SalesforceStreamer
-  VERSION = '2.0.0'.freeze
+  VERSION = '2.1.0'.freeze
 end

--- a/spec/salesforce_streamer/configuration_spec.rb
+++ b/spec/salesforce_streamer/configuration_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe SalesforceStreamer::Configuration do
   end
 
   describe '#replay_adapter[channel]' do
-    subject { config.replay_adapter[push_topic.name] }
+    subject { config.replay_adapter["/topic/#{push_topic.name}"] }
 
     let(:config) { described_class.new }
 

--- a/spec/salesforce_streamer/configuration_spec.rb
+++ b/spec/salesforce_streamer/configuration_spec.rb
@@ -39,8 +39,8 @@ RSpec.describe SalesforceStreamer::Configuration do
     end
   end
 
-  describe '#replay_adapter.call(topic)' do
-    subject { config.replay_adapter.call(push_topic) }
+  describe '#replay_adapter[channel]' do
+    subject { config.replay_adapter[push_topic.name] }
 
     let(:config) { described_class.new }
 

--- a/spec/salesforce_streamer/server_spec.rb
+++ b/spec/salesforce_streamer/server_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe SalesforceStreamer::Server do
 
       it 'subscribes to topic names' do
         expect(client).to receive(:subscribe)
-          .with(push_topics[0].name, replay: push_topics[0].replay)
+          .with(push_topics[0].name, replay: {})
         subject
       end
     end


### PR DESCRIPTION
## Description
- 43850d1 changes the expected interface for the replay adapter setting. This change fixes a bug when the old replay adapter returns an integer, then that same integer scalar would be reused despite the incrementing replayId.

From the changelog

> The `config.replay_adapter` should be an object that has an interface like Hash.
It must respond to `[]` and `[]=`. By default the adapter is an empty hash.  If
you want your push topic replayId to persist between restarts, then you should
implement a class with an appropriate interface.

```ruby
class MyReplayAdapter
  def [](channel)
    MyPersistence.get(channel)
  end
  def []=(channel, replay_id)
    MyPersistence.set(channel, replay_id)
  end
end
```

> This change was sparked by a misunderstanding of the
`Restforce::Concerns::Streaming::ReplayExtension` replay handlers.
SalesforceStreamer can eliminate some complexity and fix a bug by delegating the
responsibility of maintaining the current replayId to that ReplayExtension. The
object will be used on each request/response cycle to record and read the latest
replayId as long as the object assigned to `config.replay_adapter` responds to
`[]` and `[]=`.