### PR TITLE
adds Configuration#use_faye_extension

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    salesforce_streamer (2.1.1)
+    salesforce_streamer (2.2.0)
       dry-initializer (~> 3.0)
       faye (~> 1.4)
       restforce (>= 4.2, < 6.0)

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ SalesforceStreamer.configure do |config|
   config.exception_adapter = proc { |e| puts e }
   config.replay_adapter = MyReplayAdapter
   config.use_middleware AfterMessageReceived
+  config.use_faye_extension ErrorLoggingExtension.new
   config.manage_topics = true
 end
 ```
@@ -172,6 +173,17 @@ end
 ```
 
 This adapter will be used directly by `Restforce::ReplayExtension`.
+
+### Use Faye Extension
+
+The `config.use_faye_extension` should be given an object that responds to
+`.incoming(message, callback)` or `.outgoing(message, callback)` or both. Find
+out more about extensions from
+[Faye](https://github.com/faye/faye/blob/master/spec/ruby/server/extensions_spec.rb)
+specs.
+
+Any configured extensions are added to the Faye client used by the Restforce
+client when starting up the server.
 
 ## Development
 

--- a/lib/salesforce_streamer/configuration.rb
+++ b/lib/salesforce_streamer/configuration.rb
@@ -3,7 +3,7 @@ module SalesforceStreamer
   class Configuration
     attr_accessor :environment, :logger, :require_path, :config_file,
       :manage_topics, :exception_adapter, :replay_adapter
-    attr_reader :middleware
+    attr_reader :middleware, :faye_extensions
 
     class << self
       attr_writer :instance
@@ -26,6 +26,7 @@ module SalesforceStreamer
       @config_file = './config/streamer.yml'
       @require_path = './config/environment'
       @middleware = []
+      @faye_extensions = [ReplayIdErrorExtension.new]
     end
 
     def manage_topics?
@@ -35,6 +36,11 @@ module SalesforceStreamer
     # adds a setup proc to the middleware array
     def use_middleware(klass, *args, &block)
       @middleware << [klass, args, block]
+    end
+
+    # adds a Faye extension
+    def use_faye_extension(extension)
+      @faye_extensions << extension
     end
 
     # returns a ready to use chain of middleware

--- a/lib/salesforce_streamer/server.rb
+++ b/lib/salesforce_streamer/server.rb
@@ -27,7 +27,10 @@ module SalesforceStreamer
       return @client if @client
       @client = Restforce.new
       @client.authenticate!
-      @client.faye.add_extension ReplayIdErrorExtension.new
+      Configuration.instance.faye_extensions.each do |extension|
+        Log.debug %(adding Faye extension #{extension})
+        @client.faye.add_extension extension
+      end
       @client
     end
 

--- a/lib/salesforce_streamer/version.rb
+++ b/lib/salesforce_streamer/version.rb
@@ -1,3 +1,3 @@
 module SalesforceStreamer
-  VERSION = '2.1.1'.freeze
+  VERSION = '2.2.0'.freeze
 end


### PR DESCRIPTION
We introduce a new configuration option to specify one or more extensions to pass to the Faye client before the server starts accepting messages.

Reference https://github.com/faye/faye/blob/master/spec/ruby/server/extensions_spec.rb to see how a Faye extension behaves.