### PR TITLE
Add patch for cookie validation to solve Unknown cookie parameter 'samesite' (CookieJar::InvalidCookieError)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,3 +14,10 @@ Naming/FileName:
   Exclude:
     - 'lib/*.rb'
 
+Metrics/BlockLength:
+  Enabled: false
+
+Metrics/BlockNesting:
+  Exclude:
+    - 'lib/core_extensions/**/*.rb'
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     salesforce_streamer (2.4.0.rc1)
+      cookiejar (~> 0.3.0)
       dry-initializer (~> 3.0)
       faye (~> 1.4)
       restforce (~> 5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    salesforce_streamer (2.3.0)
+    salesforce_streamer (2.4.0.rc1)
       dry-initializer (~> 3.0)
       faye (~> 1.4)
       restforce (~> 5.0)

--- a/lib/core_extensions/cookiejar/cookie_validation.rb
+++ b/lib/core_extensions/cookiejar/cookie_validation.rb
@@ -1,27 +1,69 @@
+require 'cookiejar/cookie_validation'
+
 # Original source code at
 # https://github.com/dwaite/cookiejar/blob/master/lib/cookiejar/cookie_validation.rb
-# Re-opening the CookieValidation module to rewrite the domains_match method to
-# skip the validation of domains. Open issue at
-# https://github.com/restforce/restforce/issues/120
-module CoreExtensions
-  module CookieJar
-    module CookieValidation
-      def self.extended(base)
-        base.class_eval do
-          def self.domains_match(tested_domain, base_domain)
-            return true if tested_domain[-15..].eql?('.salesforce.com')
+module CookieJar
+  module CookieValidation
+    # Re-opening the CookieValidation module to rewrite the domains_match method to
+    # skip the validation of domains. Open issue at
+    # https://github.com/restforce/restforce/issues/120
+    def self.domains_match(tested_domain, base_domain)
+      return true if tested_domain[-15..].eql?('.salesforce.com')
 
-            # original implementation
-            base = effective_host base_domain
-            search_domains = compute_search_domains_for_host base
-            search_domains.find do |domain|
-              domain == tested_domain
+      # original implementation
+      base = effective_host base_domain
+      search_domains = compute_search_domains_for_host base
+      search_domains.find do |domain|
+        domain == tested_domain
+      end
+    end
+
+    # Implements https://github.com/dwaite/cookiejar/commit/adb79c0a14c2b347c5289e79379a1acfe34bf388
+    # which is not part of the cookiejar gem yet and is required to prevent
+    # Unknown cookie parameter 'samesite' (CookieJar::InvalidCookieError)
+    def self.parse_set_cookie(set_cookie_value)
+      args = {}
+      params = set_cookie_value.split(/;\s*/)
+
+      first = true
+      params.each do |param|
+        result = PARAM1.match param
+        unless result
+          fail InvalidCookieError,
+               "Invalid cookie parameter in cookie '#{set_cookie_value}'"
+        end
+        key = result[1].downcase.to_sym
+        keyvalue = result[2]
+        if first
+          args[:name] = result[1]
+          args[:value] = keyvalue
+          first = false
+        else
+          case key
+          when :expires
+            begin
+              args[:expires_at] = Time.parse keyvalue
+            rescue ArgumentError
+              raise unless $ERROR_INFO.message == 'time out of range'
+              args[:expires_at] = Time.at(0x7FFFFFFF)
             end
+          when :"max-age"
+            args[:max_age] = keyvalue.to_i
+          when :domain, :path
+            args[key] = keyvalue
+          when :secure
+            args[:secure] = true
+          when :httponly
+            args[:http_only] = true
+          when :samesite
+            args[:samesite] = keyvalue.downcase
+          else
+            fail InvalidCookieError, "Unknown cookie parameter '#{key}'"
           end
         end
       end
+      args[:version] = 0
+      args
     end
   end
 end
-
-CookieJar::CookieValidation.extend(CoreExtensions::CookieJar::CookieValidation)

--- a/lib/core_extensions/cookiejar/cookie_validation.rb
+++ b/lib/core_extensions/cookiejar/cookie_validation.rb
@@ -30,7 +30,7 @@ module CookieJar
         result = PARAM1.match param
         unless result
           fail InvalidCookieError,
-               "Invalid cookie parameter in cookie '#{set_cookie_value}'"
+            "Invalid cookie parameter in cookie '#{set_cookie_value}'"
         end
         key = result[1].downcase.to_sym
         keyvalue = result[2]

--- a/lib/salesforce_streamer/version.rb
+++ b/lib/salesforce_streamer/version.rb
@@ -1,3 +1,3 @@
 module SalesforceStreamer
-  VERSION = '2.3.0'.freeze
+  VERSION = '2.4.0.rc1'.freeze
 end

--- a/salesforce_streamer.gemspec
+++ b/salesforce_streamer.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.6'
 
+  spec.add_dependency 'cookiejar', '~> 0.3.0'
   spec.add_dependency 'dry-initializer', '~> 3.0'
   spec.add_dependency 'faye', '~> 1.4'
   spec.add_dependency 'restforce', '~> 5.0'


### PR DESCRIPTION
## Description
Add patch for cookie validation to solve `Unknown cookie parameter 'samesite' (CookieJar::InvalidCookieError)`

## Motivation and Context
https://github.com/dwaite/cookiejar/commit/adb79c0a14c2b347c5289e79379a1acfe34bf388 is required to have streamer running properly. Unfortunately it's not released in https://rubygems.org/gems/cookiejar.
